### PR TITLE
Use fused set_mla_kv_buffer kernel for amd gpu

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -45,7 +45,10 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _use_aiter:
     import aiter
-    from aiter import gemm_a8w8_blockscale, gemm_a8w8_bpreshuffle, get_hip_quant
+    from aiter import gemm_a8w8_bpreshuffle, get_hip_quant
+    from aiter.ops.triton.gemm_a8w8_blockscale import (
+        gemm_a8w8_blockscale as gemm_a8w8_blockscale_triton,
+    )
 
     aiter_per1x128_quant = get_hip_quant(aiter.QuantType.per_1x128)
 
@@ -284,7 +287,7 @@ def aiter_w8a8_block_fp8_linear(
     else:
         q_input, x_scale = aiter_per1x128_quant(input_2d, quant_dtype=aiter.dtypes.fp8)
 
-    output = gemm_a8w8_blockscale(
+    output = gemm_a8w8_blockscale_triton(
         q_input,
         weight,
         x_scale,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2648,7 +2648,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         k_pe: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
-        if _is_cuda:
+        if _is_cuda or _use_aiter_gfx95:
             # Save latent cache
             forward_batch.token_to_kv_pool.set_mla_kv_buffer(
                 self.attn_mha, forward_batch.out_cache_loc, kv_a.unsqueeze(1), k_pe
@@ -2673,7 +2673,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         dst_dtype: torch.dtype,
         forward_batch: ForwardBatch,
     ):
-        if _is_cuda:
+        if _is_cuda or _use_aiter_gfx95:
             kv_a, k_pe = forward_batch.token_to_kv_pool.get_mla_kv_buffer(
                 self.attn_mha, kv_indices, dst_dtype
             )


### PR DESCRIPTION
## Motivation

This PR improves the performance of a8w8 GEMM and enable mla_kv_buffer feature on MI355x.

Replace aiter gemm_a8w8_blockscale with the Triton implementation (gemm_a8w8_blockscale_triton).
Profiling shows Triton’s version provides better latency at concurrency 1–8 and significantly improves elementwise–GEMM fusion opportunities.

Enable fused set_mla_kv_buffer kernel for MI355x.
This reduces extra memory movement and cuts down several auxiliary kernels during prefill and decode.

## Modifications

- Updated aiter_w8a8_block_fp8_linear to route GEMM through Triton path when available.
- Integrated fused set_mla_kv_buffer_kernel for mi355x.

## Accuracy Tests

Model: deepseek-ai/DeepSeek-R1-0528
Accuracy: 0.933
Invalid: 0.000
Latency: 57.467 s
Output throughput: 2316.548 token/s

## Benchmarking and Profiling
Machine: MI355 * 8 GPU
Docker Image: rocm/sgl-dev:v0.5.5.post2-rocm700-mi35x-20251114

Command:
python3 -m sglang.launch_server \
--model-path /data/deepseek-ai/DeepSeek-R1-0528/ \
--host=0.0.0.0 \
--port 9000 \
--tensor-parallel-size 8 \
--trust-remote-code \
--chunked-prefill-size 196608 \
--mem-fraction-static 0.8 --disable-radix-cache \
--num-continuous-decode-steps 4 \
--max-prefill-tokens 196608 \
--enable-torch-compile \
--cuda-graph-max-bs 128

Concurrency	Before	After	
4	14720.11	13618.62	108%
8	14807.13	14005.72	106%
16	15687.87	15767.43	99%
32	17747.92	18220.36	97%
64	24644.29	26534.75	93%

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
