### PR TITLE
[AMD] Enable Fuse Shared-Expert Routing and FP8 Flatten Path

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -804,8 +804,8 @@ def biased_grouped_topk_gpu(
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         aiter_biased_grouped_topk(
-            gating_output.to(dtype=torch.float32),
-            correction_bias,
+            gating_output,
+            correction_bias.to(dtype=gating_output.dtype),
             topk_weights,
             topk_ids,
             num_expert_group,
@@ -1000,30 +1000,41 @@ def select_experts(
             else fused_shared_experts_scaling_factor
         )
 
-        topk_ids = torch.cat(
-            [
-                topk_ids,
-                torch.arange(
-                    N,
-                    N + num_fused_shared_experts,
-                    dtype=topk_ids.dtype,
-                    device=topk_ids.device,
-                ).expand(M, -1),
-            ],
-            dim=1,
+        # topk_ids = torch.cat(
+        #     [
+        #         topk_ids,
+        #         torch.arange(
+        #             N,
+        #             N + num_fused_shared_experts,
+        #             dtype=topk_ids.dtype,
+        #             device=topk_ids.device,
+        #         ).expand(M, -1),
+        #     ],
+        #     dim=1,
+        # )
+
+        # topk_weights = torch.cat(
+        #     [
+        #         topk_weights,
+        #         torch.full(
+        #             (topk_weights.size(0), num_fused_shared_experts),
+        #             scale_factor,
+        #             dtype=topk_weights.dtype,
+        #             device=topk_weights.device,
+        #         ),
+        #     ],
+        #     dim=1,
+        # )
+        from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_kernels import (
+            fused_append_shared_experts,
         )
 
-        topk_weights = torch.cat(
-            [
-                topk_weights,
-                torch.full(
-                    (topk_weights.size(0), num_fused_shared_experts),
-                    scale_factor,
-                    dtype=topk_weights.dtype,
-                    device=topk_weights.device,
-                ),
-            ],
-            dim=1,
+        topk_ids, topk_weights = fused_append_shared_experts(
+            topk_ids,
+            topk_weights,
+            num_fused_shared_experts,
+            scale_factor,
+            N,  # base id for shared experts
         )
 
     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -991,7 +991,6 @@ def select_experts(
             renormalize=renormalize,
         )
 
-    # TODO: fused ops of shared experts in topk function itself when num_fused_shared_experts > 0.
     if num_fused_shared_experts > 0 and _use_aiter:
         M, N = router_logits.shape
         scale_factor = (
@@ -1000,31 +999,7 @@ def select_experts(
             else fused_shared_experts_scaling_factor
         )
 
-        # topk_ids = torch.cat(
-        #     [
-        #         topk_ids,
-        #         torch.arange(
-        #             N,
-        #             N + num_fused_shared_experts,
-        #             dtype=topk_ids.dtype,
-        #             device=topk_ids.device,
-        #         ).expand(M, -1),
-        #     ],
-        #     dim=1,
-        # )
-
-        # topk_weights = torch.cat(
-        #     [
-        #         topk_weights,
-        #         torch.full(
-        #             (topk_weights.size(0), num_fused_shared_experts),
-        #             scale_factor,
-        #             dtype=topk_weights.dtype,
-        #             device=topk_weights.device,
-        #         ),
-        #     ],
-        #     dim=1,
-        # )
+        # Lazy import to avoid circular-import issues
         from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_kernels import (
             fused_append_shared_experts,
         )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -168,10 +168,14 @@ _is_gfx95_supported = is_gfx95_supported()
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 
 if _use_aiter_gfx95:
+
     from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
         batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
     )
-    from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
+    from aiter.ops.triton.fused_fp8_quant import (
+        fused_flatten_fp8_group_quant,
+        fused_rms_fp8_group_quant,
+    )
 
     from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import (
@@ -2001,6 +2005,11 @@ class DeepseekV2AttentionMLA(nn.Module):
             if self.o_proj.weight.dtype == torch.uint8:
                 attn_bmm_output = attn_bmm_output.transpose(0, 1)
                 attn_bmm_output = fused_flatten_mxfp4_quant(attn_bmm_output)
+            elif self.o_proj.weight.dtype == torch.float8_e4m3fn:
+                attn_bmm_output = attn_bmm_output.transpose(0, 1)
+                attn_bmm_output = fused_flatten_fp8_group_quant(
+                    attn_bmm_output, group_size=128, dtype_quant=torch.float8_e4m3fn
+                )
             else:
                 attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
 


### PR DESCRIPTION
## Motivation
This PR introduces two performance improvements for DeepseekR1-0528 (fp8):

1. Support aiter fused_flatten_fp8_group_quant for fp8 DeepSeek model
Adds a fused path for fp8 projection outputs using fused_flatten_fp8_group_quant, extending parity with existing MXFP4 support.

2. Fused shared-expert routing in MoE
The original PyTorch implementation used multiple kernels (arange, full, cat) to append shared experts to topk_ids and topk_weights. We replace this entire sequence with a single Triton fused kernel, reducing kernel launches and improving GPU utilization.

## Modifications
DeepSeek FP8 Projection Path
- Added fused projection path for fp8 deepseek model.

MoE: Fused Shared-Expert Append Kernel
- Introduced a fused shared-expert append Triton kernel (_fused_append_shared_experts_kernel) to replace the slow PyTorch top-k concatenation path .

## Accuracy Tests
Model: deepseek-ai/DeepSeek-R1-0528
Accuracy: 0.932
Invalid: 0.000
Latency: 50.676 s
Output throughput: 2637.074 token/s

## Benchmarking and Profiling
Machine: MI355 * 8 GPU
Docker Image: rocm/sgl-dev:v0.5.5.post2-rocm700-mi35x-20251114

Command:
python3 -m sglang.launch_server
--model-path /data/deepseek-ai/DeepSeek-R1-0528/
--host=0.0.0.0
--port 9000
--tensor-parallel-size 8
--trust-remote-code
--chunked-prefill-size 196608
--mem-fraction-static 0.8 --disable-radix-cache
--num-continuous-decode-steps 4
--max-prefill-tokens 196608
--enable-torch-compile
--cuda-graph-max-bs 128

Concurrency Before After
4	13491.62	13132.46
8	13763.41	13623.41
16	15228.69	15136.62
32	17837.13	17756.17
64	23529.12	22972.99


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
